### PR TITLE
Add colored output for error messages in main function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ inkwell = { version = "0.4", features = ["llvm14-0"] }
 # Error management
 thiserror = "2.0.12"
 
+# Colors for terminal output
+colored = "3.0"
+
 [build-dependencies]
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,13 @@
 use std::env;
+use colored::Colorize;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     println!("Arguments: {:?}", args);
+    if args.len() < 2
+    {
+        eprintln!("{}: {} no input files", "cc1".bold(), "fatal error:".red().bold());
+        eprintln!("compilation terminated.");
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
This pull request introduces terminal output enhancements by adding colored text for error messages, improving user feedback during execution. It includes the addition of a new dependency and updates to the main application logic.

### Terminal output enhancements:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R20-R22): Added the `colored` crate (version 3.0) to enable colored text output in the terminal.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR2-R12): Integrated the `colored` crate to format error messages with bold and colored text when no input files are provided, improving clarity in error reporting.